### PR TITLE
precisazione dell'esempio prestazionale

### DIFF
--- a/documento-in-consultazione/definizioni.rst
+++ b/documento-in-consultazione/definizioni.rst
@@ -188,7 +188,7 @@ Tabella 9: esempio di requisito di qualità
 +------------------+-------------------------------------------------------------------------------------------------------+
 | **ID Requisito** | **Descrizione**                                                                                       |
 +==================+=======================================================================================================+
-| RQ1              | Il tempo di risposta del sistema all'inserimento della password utente deve essere inferiore a 10 sec |
+| RQ1              | Il tempo di risposta del sistema (90° pecentile) all'inserimento della password utente deve essere inferiore a 10 sec. Ovvero, il 90 percento delle richieste di inserimento password devono rispondere all'utente entro 10 secondi. |
 +------------------+-------------------------------------------------------------------------------------------------------+
 
 3.1.4 Requisiti di sistema/ambiente


### PR DESCRIPTION
i tempi di risposta per i test prestazionali sono misurabili in modo accurato solo usando i percentili, non la media:
* https://www.dynatrace.com/news/blog/why-averages-suck-and-percentiles-are-great/
* https://stackoverflow.com/questions/37394895/what-percentiles-metrics-reflect-your-app-performance

inoltre precisare nel requisito la tipologia di rilevazione desiderata per i tempi di risposta evita fraintendimenti.  :-)